### PR TITLE
Move testing to a test cookbook and other misc cleanup

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -64,22 +64,16 @@ platforms:
   driver:
     image: ubuntu-upstart:12.04
     pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
 
 - name: ubuntu-14.04
   driver:
     image: ubuntu-upstart:14.04
     pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
 
 - name: ubuntu-16.04
   driver:
     image: ubuntu:16.04
     pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
 
 - name: opensuse-13.2
   driver:
@@ -98,38 +92,13 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[chef_nginx::default]
+      - recipe[test::default]
   - name: source
     run_list:
-      - recipe[chef_nginx::default]
-    attributes:
-      nginx:
-        install_method: source
+      - recipe[test::source]
   - name: upstream_repo
     run_list:
-      - recipe[chef_nginx::repo]
-      - recipe[chef_nginx::default]
-    attributes:
-      nginx:
-        repo_source: nginx
+      - recipe[test::upstream_repo]
   - name: modules
     run_list:
-      - recipe[chef_nginx::source]
-    attributes:
-      nginx:
-        source:
-          modules:
-            - chef_nginx::headers_more_module
-            - chef_nginx::http_auth_request_module
-            - chef_nginx::http_echo_module
-            - chef_nginx::http_geoip_module
-            - chef_nginx::http_gzip_static_module
-            - chef_nginx::http_realip_module
-            - chef_nginx::http_v2_module
-            - chef_nginx::http_ssl_module
-            - chef_nginx::http_stub_status_module
-            - chef_nginx::naxsi_module
-            - chef_nginx::ngx_devel_module
-            - chef_nginx::ngx_lua_module
-            - chef_nginx::openssl_source
-            - chef_nginx::upload_progress_module
+      - recipe[test::modules]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,21 +12,15 @@ platforms:
   - name: centos-6.8
   - name: centos-7.2
   - name: debian-7.11
-    run_list: apt::default
   - name: debian-8.5
-    run_list: apt::default
   - name: fedora-24
     run_list: yum::dnf_yum_compat
   - name: opensuse-13.2
   - name: opensuse-42.1
   - name: ubuntu-12.04
-    run_list: apt::default
   - name: ubuntu-14.04
-    run_list: apt::default
   - name: ubuntu-16.04
-    run_list: apt::default
   - name: ubuntu-16.04-chef-12.1
-    run_list: apt::default
     driver_config:
       box: bento/ubuntu-16.04
     provisioner:
@@ -35,47 +29,22 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[chef_nginx::default]
+      - recipe[test::default]
     excludes:
       - opensuse-13.2 # lacks nginx package
   - name: source
     run_list:
-      - recipe[chef_nginx::default]
-    attributes:
-      nginx:
-        install_method: source
+      - recipe[test::source]
     excludes:
       - ubuntu-16.04-chef-12.1
   - name: upstream_repo
     run_list:
-      - recipe[chef_nginx::repo]
-      - recipe[chef_nginx::default]
-    attributes:
-      nginx:
-        repo_source: nginx
+      - recipe[test::upstream_repo]
     excludes:
-      - fedora-24
+      - fedora-24 # lacks nginx repo
       - ubuntu-16.04-chef-12.1
   - name: modules
     run_list:
-      - recipe[chef_nginx::source]
-    attributes:
-      nginx:
-        source:
-          modules:
-            - chef_nginx::headers_more_module
-            - chef_nginx::http_auth_request_module
-            - chef_nginx::http_echo_module
-            - chef_nginx::http_geoip_module
-            - chef_nginx::http_gzip_static_module
-            - chef_nginx::http_realip_module
-            - chef_nginx::http_v2_module
-            - chef_nginx::http_ssl_module
-            - chef_nginx::http_stub_status_module
-            - chef_nginx::naxsi_module
-            - chef_nginx::ngx_devel_module
-            - chef_nginx::ngx_lua_module
-            - chef_nginx::openssl_source
-            - chef_nginx::upload_progress_module
+      - recipe[test::modules]
     excludes:
       - ubuntu-16.04-chef-12.1

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+group :integration do
+  cookbook 'test', path: 'test/cookbooks/test'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Ideally we'd offer perfect backwards compatibility forever, but in order to main
 
 ### Other changes
 
-- Chefspec platform updates and minor fixes
 - Added support for openSUSE source installs using systemd
 - Retry downloads of the nginx source file as the mirror sometimes fails to load
 - Download the nginx source from the secure nginx.org site
@@ -22,11 +21,16 @@ Ideally we'd offer perfect backwards compatibility forever, but in order to main
 - Install source install pre-reqs using multi-package which speeds up Chef runs
 - Add testing in Travis with Kitchen Dokken for full integration testing of each PR
 - Add integration test on Chef 12.1 as well as the latest Chef to ensure compatibility with the oldest release we support
+- Remove installation of apt-transport-https and instead increase the apt dependency to >= 2.9.1 which includes the installation of apt-transport-https
+- Don't try to setup the nginx.org repo on Fedora as this will fail
+- Better log when trying to setup repositories on unsupported platforms
 - Fixed source_url and issue_url in the metadata to point to the correct URLs
 - Removed Chef 10 compatibility code
+- Chefspec platform updates and minor fixes
 - Replace all usage of node.set with node.normal to avoid deprecation notices
 - Remove the suse init script that isn't used anymore
 - Speed up the specs with caching
+- Move test attributes and runlists out the kitchen.yml files and into a test cookbook
 
 ## 2.9.0 (2016-08-12)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,8 +21,7 @@
 #
 
 # In order to update the version, the checksum attribute must be changed too.
-# This attribute is in the source.rb file, though we recommend overriding
-# attributes by modifying a role, or the node itself.
+# This attribute is defined in the source.rb attribute file
 default['nginx']['version']      = '1.10.1'
 default['nginx']['package_name'] = 'nginx'
 default['nginx']['port']         = '80'
@@ -33,8 +32,7 @@ default['nginx']['log_dir_perm'] = '0750'
 default['nginx']['binary']       = '/usr/sbin/nginx'
 default['nginx']['default_root'] = '/var/www/nginx-default'
 default['nginx']['ulimit']       = '1024'
-
-default['nginx']['pid'] = '/var/run/nginx.pid'
+default['nginx']['pid']          = '/var/run/nginx.pid'
 
 case node['platform_family']
 when 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version '2.9.0'
 recipe 'chef_nginx', 'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'chef_nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'
 
-depends 'apt'
+depends 'apt', '>= 2.9.1'
 depends 'build-essential'
 depends 'ohai', '>= 4.1.0'
 depends 'runit', '>= 1.6.0'

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -19,7 +19,7 @@
 #
 
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel'
 
   yum_repository 'nginx' do
     description  'Nginx.org Repository'
@@ -29,6 +29,7 @@ when 'rhel', 'fedora'
   end
 
 when 'suse'
+
   zypper_repo 'nginx' do
     repo_name 'Nginx.org Repository'
     uri 'http://nginx.org/packages/sles/12'
@@ -36,11 +37,17 @@ when 'suse'
   end
 
 when 'debian'
+
   apt_repository 'nginx' do
     uri          node['nginx']['upstream_repository']
     distribution node['lsb']['codename']
     components   %w(nginx)
     deb_src      true
     key          'http://nginx.org/keys/nginx_signing.key'
+  end
+
+else
+  log "nginx.org does not maintain packages for platform #{node['platform']}. Cannot setup the upstream repo!" do
+    level :warn
   end
 end

--- a/recipes/repo_passenger.rb
+++ b/recipes/repo_passenger.rb
@@ -24,7 +24,6 @@ when 'rhel', 'fedora'
 
 when 'debian'
   include_recipe 'apt::default'
-  package 'apt-transport-https'
 
   apt_repository 'phusionpassenger' do
     uri 'https://oss-binaries.phusionpassenger.com/apt/passenger'

--- a/recipes/repo_passenger.rb
+++ b/recipes/repo_passenger.rb
@@ -18,8 +18,8 @@
 case node['platform_family']
 when 'rhel', 'fedora'
 
-  log 'There is not official phusion passenger repo for redhat based systems.' do
-    level :info
+  log 'There is not official phusion passenger repo for redhat based systems. Skipping repo setup!' do
+    level :warn
   end
 
 when 'debian'

--- a/recipes/repo_passenger.rb
+++ b/recipes/repo_passenger.rb
@@ -29,7 +29,7 @@ if platform_family?('debian')
 
   include_recipe 'chef_nginx::passenger'
 else
-  log "There is not official phusion passenger repo platform #{node['platform']} redhat based systems. Skipping repo setup!" do
+  log "There is not official phusion passenger repo platform #{node['platform']}. Skipping repo setup!" do
     level :warn
   end
 end

--- a/recipes/repo_passenger.rb
+++ b/recipes/repo_passenger.rb
@@ -15,14 +15,7 @@
 # limitations under the License.
 #
 
-case node['platform_family']
-when 'rhel', 'fedora'
-
-  log 'There is not official phusion passenger repo for redhat based systems. Skipping repo setup!' do
-    level :warn
-  end
-
-when 'debian'
+if platform_family?('debian')
   include_recipe 'apt::default'
 
   apt_repository 'phusionpassenger' do
@@ -35,4 +28,8 @@ when 'debian'
   end
 
   include_recipe 'chef_nginx::passenger'
+else
+  log "There is not official phusion passenger repo platform #{node['platform']} redhat based systems. Skipping repo setup!" do
+    level :warn
+  end
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -21,11 +21,8 @@
 # limitations under the License.
 #
 
-nginx_url = node['nginx']['source']['url'] ||
-            "https://nginx.org/download/nginx-#{node['nginx']['source']['version']}.tar.gz"
-
-node.normal['nginx']['binary']          = node['nginx']['source']['sbin_path']
-node.normal['nginx']['daemon_disable']  = true
+node.normal['nginx']['binary'] = node['nginx']['source']['sbin_path']
+node.normal['nginx']['daemon_disable'] = true
 
 unless node['nginx']['source']['use_existing_user']
   user node['nginx']['user'] do
@@ -40,7 +37,7 @@ include_recipe 'chef_nginx::commons_dir'
 include_recipe 'chef_nginx::commons_script'
 include_recipe 'build-essential::default'
 
-src_filepath = "#{Chef::Config['file_cache_path'] || '/tmp'}/nginx-#{node['nginx']['source']['version']}.tar.gz"
+src_filepath = "#{Chef::Config['file_cache_path']}/nginx-#{node['nginx']['source']['version']}.tar.gz"
 
 # install prereqs
 package value_for_platform_family(
@@ -49,8 +46,8 @@ package value_for_platform_family(
   %w(default) => %w(libpcre3 libpcre3-dev libssl-dev tar)
 )
 
-remote_file nginx_url do
-  source   nginx_url
+remote_file 'nginx source' do
+  source   node['nginx']['source']['url']
   checksum node['nginx']['source']['checksum']
   path     src_filepath
   backup   false

--- a/spec/unit/recipes/repo_spec.rb
+++ b/spec/unit/recipes/repo_spec.rb
@@ -36,8 +36,10 @@ describe 'chef_nginx::repo' do
       ChefSpec::ServerRunner.new(platform: 'fedora', version: '24').converge(described_recipe)
     end
 
-    it 'adds yum repository' do
-      expect(chef_run).to create_yum_repository('nginx')
+    it "logs a message that the repo doesn't support Fedora" do
+      expect(chef_run).to write_log(
+        'nginx.org does not maintain packages for platform fedora. Cannot setup the upstream repo!'
+      ).with(level: :warn)
     end
   end
 end

--- a/test/cookbooks/test/README.md
+++ b/test/cookbooks/test/README.md
@@ -1,0 +1,1 @@
+Test cookbook for chef_nginx

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -1,0 +1,7 @@
+name 'test'
+maintainer 'Chef Software, Inc.'
+maintainer_email 'cookbooks@chef.io'
+license 'Apache 2.0'
+version '1.0.0'
+
+depends 'chef_nginx'

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,0 +1,3 @@
+apt_update 'update' if platform_family?('debian')
+
+include_recipe 'chef_nginx::default'

--- a/test/cookbooks/test/recipes/modules.rb
+++ b/test/cookbooks/test/recipes/modules.rb
@@ -1,0 +1,20 @@
+node.default['nginx']['install_method'] = 'source'
+node.default['nginx']['source']['modules'] = %w(
+  chef_nginx::headers_more_module
+  chef_nginx::http_auth_request_module
+  chef_nginx::http_echo_module
+  chef_nginx::http_geoip_module
+  chef_nginx::http_gzip_static_module
+  chef_nginx::http_realip_module
+  chef_nginx::http_v2_module
+  chef_nginx::http_ssl_module
+  chef_nginx::http_stub_status_module
+  chef_nginx::naxsi_module
+  chef_nginx::ngx_devel_module
+  chef_nginx::ngx_lua_module
+  chef_nginx::openssl_source
+  chef_nginx::upload_progress_module)
+
+apt_update 'update' if platform_family?('debian')
+
+include_recipe 'chef_nginx::default'

--- a/test/cookbooks/test/recipes/source.rb
+++ b/test/cookbooks/test/recipes/source.rb
@@ -1,0 +1,5 @@
+node.default['nginx']['install_method'] = 'source'
+
+apt_update 'update' if platform_family?('debian')
+
+include_recipe 'chef_nginx::default'

--- a/test/cookbooks/test/recipes/upstream_repo.rb
+++ b/test/cookbooks/test/recipes/upstream_repo.rb
@@ -1,0 +1,6 @@
+node.default['nginx']['repo_source'] = 'nginx'
+
+apt_update 'update' if platform_family?('debian')
+
+include_recipe 'chef_nginx::repo'
+include_recipe 'chef_nginx::default'


### PR DESCRIPTION
The source cookbook has some odd attribute logic that I _think_ is legacy code to deal with Chef 10, but it really serves no purpose at this point.

Also split out testing logic into a test recipe that allows us to keep the two kitchen configs synced easier

Don't install apt-transport-https as it's already installed via apt::default

Simplify the logic for setting up the passenger repo and log at warning level for any non-debian platform

Signed-off-by: Tim Smith tsmith@chef.io
