### PR TITLE
Systemd support & additional testing

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,7 +16,7 @@ platforms:
   - name: fedora-24
     run_list: yum::dnf_yum_compat
   - name: opensuse-13.2
-  - name: opensuse-42.1
+  - name: opensuse-leap-42.1
   - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: ubuntu-16.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,25 @@ env:
   - INSTANCE=source-ubuntu-1204
   - INSTANCE=source-ubuntu-1404
   - INSTANCE=source-ubuntu-1604
+  - INSTANCE=modules-centos-6
+  - INSTANCE=modules-centos-7
+  - INSTANCE=modules-debian-7
+  - INSTANCE=modules-debian-8
+  - INSTANCE=modules-fedora-latest
+  - INSTANCE=modules-opensuse-132
+  - INSTANCE=modules-opensuse-421
+  - INSTANCE=modules-ubuntu-1204
+  - INSTANCE=modules-ubuntu-1404
+  - INSTANCE=modules-ubuntu-1604
+  - INSTANCE=upstream_repo-centos-6
+  - INSTANCE=upstream_repo-centos-7
+  - INSTANCE=upstream_repo-debian-7
+  - INSTANCE=upstream_repo-debian-8
+  - INSTANCE=upstream_repo-opensuse-132
+  - INSTANCE=upstream_repo-opensuse-421
+  - INSTANCE=upstream_repo-ubuntu-1204
+  - INSTANCE=upstream_repo-ubuntu-1404
+  - INSTANCE=upstream_repo-ubuntu-1604
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ env:
   - INSTANCE=source-ubuntu-1204
   - INSTANCE=source-ubuntu-1404
   - INSTANCE=source-ubuntu-1604
-  - INSTANCE=modules-centos-6
   - INSTANCE=modules-centos-7
   - INSTANCE=modules-debian-7
   - INSTANCE=modules-debian-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,15 +49,15 @@ env:
   - INSTANCE=modules-ubuntu-1204
   - INSTANCE=modules-ubuntu-1404
   - INSTANCE=modules-ubuntu-1604
-  - INSTANCE=upstream_repo-centos-6
-  - INSTANCE=upstream_repo-centos-7
-  - INSTANCE=upstream_repo-debian-7
-  - INSTANCE=upstream_repo-debian-8
-  - INSTANCE=upstream_repo-opensuse-132
-  - INSTANCE=upstream_repo-opensuse-421
-  - INSTANCE=upstream_repo-ubuntu-1204
-  - INSTANCE=upstream_repo-ubuntu-1404
-  - INSTANCE=upstream_repo-ubuntu-1604
+  - INSTANCE=upstream-repo-centos-6
+  - INSTANCE=upstream-repo-centos-7
+  - INSTANCE=upstream-repo-debian-7
+  - INSTANCE=upstream-repo-debian-8
+  - INSTANCE=upstream-repo-opensuse-132
+  - INSTANCE=upstream-repo-opensuse-421
+  - INSTANCE=upstream-repo-ubuntu-1204
+  - INSTANCE=upstream-repo-ubuntu-1404
+  - INSTANCE=upstream-repo-ubuntu-1604
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ Ideally we'd offer perfect backwards compatibility forever, but in order to main
 - Minimum chef-client version is now 12.1 or later, which will enable support for custom resources and init system detection in the future.
 - Support for Gentoo has been removed. Chef does not directly support the Gentoo platform with packages and there is no Bento image to use for Test Kitchen integration tests.
 - Support for the bluepill init system has been removed. Usage of this init system has declined and supporting it added a cookbook dependency / code complexity.
+- Ubuntu source installs will no longer default to runit, and will instead use either Upstart or Systemd depending on the release. You can still force the use of runit by setting default['nginx']['init_style'] to 'runit'. Runit was used historically before reliable inits were included on Ubuntu, but both Upstart and Systemd have the concept or restarting on failure, which was the main reason for choosing Runit over sys-v init.
 
 ### Other changes
 
-- Added support for openSUSE source installs using systemd
+- Don't setup the YUM EPEL repo on Fedora as it's not needed
+- Systemd based platforms will now use systemd by default for source installs
 - Retry downloads of the nginx source file as the mirror sometimes fails to load
 - Download the nginx source from the secure nginx.org site
 - Updated the Ohai plugin to avoid deprecation notices and function better on non us-en locale systems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,17 @@ This file is used to list changes made in each version of the nginx cookbook.
 
 Ideally we'd offer perfect backwards compatibility forever, but in order to maintain the cookbook going forward we've evaluated the current scope of the cookbook and removed lesser used functionality that added code complexity.
 
+<<<<<<< 58ecdd5afd09ea372a5b394f8924c82410837897
 - Minimum chef-client version is now 12.1 or later, which will enable support for custom resources and init system detection in the future.
 - Support for Gentoo has been removed. Chef does not directly support the Gentoo platform with packages and there is no Bento image to use for Test Kitchen integration tests.
 - Support for the bluepill init system has been removed. Usage of this init system has declined and supporting it added a cookbook dependency / code complexity.
 - Ubuntu source installs will no longer default to runit, and will instead use either Upstart or Systemd depending on the release. You can still force the use of runit by setting default['nginx']['init_style'] to 'runit'. Runit was used historically before reliable inits were included on Ubuntu, but both Upstart and Systemd have the concept or restarting on failure, which was the main reason for choosing Runit over sys-v init.
+=======
+- The minimum chef-client version is now 12.1 or later, which will enable support for custom resources and init system detection in the future.
+- Support for Gentoo has been removed. Gentoo is not a supported platform on Chef and there is no Bento image to use for Test Kitchen integration tests.
+- Support for the bluepill init system has been removed. Usage of this init system has declined, and supporting it added a cookbook dependency as well as code complexity.
+- Ubuntu source installs will no longer default to runit, and will instead use either Upstart or Systemd depending on the release of Ubuntu. You can still force the use of runit by setting default['nginx']['init_style'] to 'runit'. Runit was used historically before reliable init systems were shipped with Ubuntu. Both Upstart and Systemd have the concept of restarting on failure, which was the main reason for choosing Runit over sys-v init.
+>>>>>>> Reword the breaking changes in the changelog
 
 ### Other changes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,9 +46,11 @@ when 'debian'
       default['nginx']['init_style'] = 'upstart'
     end
   end
-when 'rhel', 'fedora'
+when 'rhel'
   default['nginx']['user']        = 'nginx'
   default['nginx']['repo_source'] = 'epel'
+when 'fedora'
+  default['nginx']['user']        = 'nginx'
 when 'freebsd'
   default['nginx']['package_name'] = 'www/nginx'
   default['nginx']['user']         = 'www'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,17 +33,16 @@ default['nginx']['binary']       = '/usr/sbin/nginx'
 default['nginx']['default_root'] = '/var/www/nginx-default'
 default['nginx']['ulimit']       = '1024'
 default['nginx']['pid']          = '/var/run/nginx.pid'
+default['nginx']['init_style']   = node['init_package']
 
 case node['platform_family']
 when 'debian'
-  default['nginx']['user']       = 'www-data'
-  default['nginx']['init_style'] = 'runit'
+  default['nginx']['user'] = 'www-data'
   if node['platform'] == 'ubuntu' && node['platform_version'].to_f > 14.04
     default['nginx']['pid'] = '/run/nginx.pid'
   end
 when 'rhel', 'fedora'
   default['nginx']['user']        = 'nginx'
-  default['nginx']['init_style']  = 'init'
   default['nginx']['repo_source'] = 'epel'
 when 'freebsd'
   default['nginx']['package_name'] = 'www/nginx'
@@ -54,11 +53,9 @@ when 'freebsd'
   default['nginx']['default_root'] = '/usr/local/www/nginx-dist'
 when 'suse'
   default['nginx']['user']       = 'wwwrun'
-  default['nginx']['init_style'] = 'systemd'
   default['nginx']['group']      = 'www'
 else
   default['nginx']['user']       = 'www-data'
-  default['nginx']['init_style'] = 'init'
 end
 
 default['nginx']['upstart']['runlevels']     = '2345'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,8 +38,13 @@ default['nginx']['init_style']   = node['init_package']
 case node['platform_family']
 when 'debian'
   default['nginx']['user'] = 'www-data'
-  if node['platform'] == 'ubuntu' && node['platform_version'].to_f > 14.04
-    default['nginx']['pid'] = '/run/nginx.pid'
+  if node['platform'] == 'ubuntu'
+    if node['platform_version'].to_f >= 14.04
+      default['nginx']['pid'] = '/run/nginx.pid'
+    else
+      # init_package identifies 12.04/14.04 as init, but we should be using upstart here
+      default['nginx']['init_style'] = 'upstart'
+    end
   end
 when 'rhel', 'fedora'
   default['nginx']['user']        = 'nginx'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,18 +33,12 @@ default['nginx']['binary']       = '/usr/sbin/nginx'
 default['nginx']['default_root'] = '/var/www/nginx-default'
 default['nginx']['ulimit']       = '1024'
 default['nginx']['pid']          = '/var/run/nginx.pid'
-default['nginx']['init_style']   = node['init_package']
 
 case node['platform_family']
 when 'debian'
   default['nginx']['user'] = 'www-data'
-  if node['platform'] == 'ubuntu'
-    if node['platform_version'].to_f >= 14.04
-      default['nginx']['pid'] = '/run/nginx.pid'
-    else
-      # init_package identifies 12.04/14.04 as init, but we should be using upstart here
-      default['nginx']['init_style'] = 'upstart'
-    end
+  if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 14.04
+    default['nginx']['pid'] = '/run/nginx.pid'
   end
 when 'rhel'
   default['nginx']['user']        = 'nginx'

--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -21,6 +21,13 @@
 
 include_attribute 'chef_nginx::default'
 
+default['nginx']['init_style'] = if node['platform'] == 'ubuntu' && node['platform_version'].to_f <= 14.04
+                                   # init_package identifies 12.04/14.04 as init, but we should be using upstart here
+                                   'upstart'
+                                 else
+                                   node['init_package']
+                                 end
+
 default['nginx']['source']['version']                 = node['nginx']['version']
 default['nginx']['source']['prefix']                  = "/opt/nginx-#{node['nginx']['source']['version']}"
 default['nginx']['source']['conf_path']               = "#{node['nginx']['dir']}/nginx.conf"

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -128,7 +128,10 @@ when 'upstart'
     action   :nothing
   end
 when 'systemd'
-  template '/usr/lib/systemd/system/nginx.service' do
+
+  systemd_prefix = platform_family?('suse') ? '/usr/lib' : '/lib'
+
+  template "#{systemd_prefix}/systemd/system/nginx.service" do
     source 'nginx.service.erb'
   end
 

--- a/spec/unit/recipes/package_spec.rb
+++ b/spec/unit/recipes/package_spec.rb
@@ -65,6 +65,21 @@ describe 'chef_nginx::package' do
     end
   end
 
+  context 'fedora platform family' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(
+        platform: 'fedora',
+        version: '24'
+      ).converge(described_recipe)
+    end
+
+    # epel should not be used on fedora since epel is basically fedora packages
+    # backported to RHEL
+    it 'does not include yum-epel recipe' do
+      expect(chef_run).to_not include_recipe('yum-epel')
+    end
+  end
+
   context 'rhel platform family' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new(

--- a/spec/unit/recipes/repo_spec.rb
+++ b/spec/unit/recipes/repo_spec.rb
@@ -21,6 +21,16 @@ describe 'chef_nginx::repo' do
     end
   end
 
+  context 'SUSE' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'opensuse', version: '13.2').converge(described_recipe)
+    end
+
+    it 'adds zypper repository' do
+      expect(chef_run).to add_zypper_repo('nginx')
+    end
+  end
+
   context 'RHEL' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'centos', version: '6.8').converge(described_recipe)

--- a/spec/unit/recipes/source_spec.rb
+++ b/spec/unit/recipes/source_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'chef_nginx::source' do
-
   shared_examples_for 'all platforms' do
     it 'creates nginx user' do
       expect(chef_run).to create_user('www-data').with(

--- a/spec/unit/recipes/source_spec.rb
+++ b/spec/unit/recipes/source_spec.rb
@@ -1,8 +1,74 @@
 require 'spec_helper'
 
 describe 'chef_nginx::source' do
+
+  shared_examples_for 'all platforms' do
+    it 'creates nginx user' do
+      expect(chef_run).to create_user('www-data').with(
+        system: true,
+        shell: '/bin/false',
+        home: '/var/www'
+      )
+    end
+
+    %w(
+      ohai_plugin
+      commons_dir
+      commons_script
+      commons_conf
+    ).each do |recipe|
+      it "includes the #{recipe} recipe" do
+        expect(chef_run).to include_recipe("chef_nginx::#{recipe}")
+      end
+    end
+
+    it 'includes build-essential recipe' do
+      expect(chef_run).to include_recipe('build-essential::default')
+    end
+
+    it 'downloads nginx sources' do
+      src_file = "#{Chef::Config['file_cache_path']}/nginx-#{@ngx_version}.tar.gz"
+      expect(chef_run).to create_remote_file(src_file).with(
+        backup: false
+      )
+    end
+
+    it 'creates mime.types file' do
+      expect(chef_run).to create_cookbook_file('/etc/nginx/mime.types')
+    end
+
+    it 'marks nginx to be reloaded when we change the mime.types file' do
+      expect(chef_run.cookbook_file("#{chef_run.node['nginx']['dir']}/mime.types")).to notify('service[nginx]').to(:reload).delayed
+    end
+
+    it 'unarchives source' do
+      expect(chef_run).to run_bash('unarchive_source')
+    end
+
+    it 'includes all the source modules recipes' do
+      expect(chef_run).to include_recipe('chef_nginx::http_gzip_static_module')
+      expect(chef_run).to include_recipe('chef_nginx::http_ssl_module')
+    end
+
+    it 'compiles nginx source' do
+      expect(chef_run).to run_bash('compile_nginx_source')
+    end
+
+    it 'marks nginx to be reloaded when we compile nginx source' do
+      expect(chef_run.bash('compile_nginx_source')).to notify('service[nginx]').to(:restart).delayed
+    end
+
+    it 'marks ohai nginx to be reloaded when we compile nginx source' do
+      expect(chef_run.bash('compile_nginx_source')).to notify('ohai[reload_nginx]').to(:reload).immediately
+    end
+
+    it 'enables nginx service' do
+      expect(chef_run).to enable_service('nginx')
+    end
+  end
+
   cached(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'debian', version: '8.5').converge(described_recipe)
+    ChefSpec::ServerRunner.new(platform: 'debian', version: '7.11').converge(described_recipe)
   end
 
   before do
@@ -11,135 +77,94 @@ describe 'chef_nginx::source' do
     @ngx_version = chef_run.node['nginx']['source']['version']
   end
 
-  it 'creates nginx user' do
-    expect(chef_run).to create_user('www-data').with(
-      system: true,
-      shell: '/bin/false',
-      home: '/var/www'
-    )
+  it 'enables daemon mode in nginx' do
+    expect(chef_run.node['nginx']['daemon_disable']).to be(false)
   end
 
-  %w(
-    ohai_plugin
-    commons_dir
-    commons_script
-    commons_conf
-  ).each do |recipe|
-    it "includes the #{recipe} recipe" do
-      expect(chef_run).to include_recipe("chef_nginx::#{recipe}")
-    end
+  it 'creates init script' do
+    expect(chef_run).to render_file('/etc/init.d/nginx')
   end
 
-  it 'includes build-essential recipe' do
-    expect(chef_run).to include_recipe('build-essential::default')
+  it 'generates defaults configuration' do
+    expect(chef_run).to render_file('/etc/default/nginx')
   end
 
   it 'installs packages dependencies' do
     expect(chef_run).to install_package(['libpcre3', 'libpcre3-dev', 'libssl-dev', 'tar'])
   end
 
-  context 'Rhel family' do
+  context 'On Debian 8' do
+    cached(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'debian', version: '8.5').converge(described_recipe)
+    end
+
+    it 'creates systemd unit file' do
+      expect(chef_run).to render_file('/lib/systemd/system/nginx.service')
+    end
+
+    it 'generates defaults configuration' do
+      expect(chef_run).to render_file('/etc/default/nginx')
+    end
+  end
+
+  context 'Freebsd familly' do
+    cached(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'freebsd', version: '10.3').converge(described_recipe)
+    end
+
+    it 'does not create the init script' do
+      expect(chef_run).to_not render_file('/etc/init.d/nginx')
+    end
+
+    it 'does not generate defaults configuration' do
+      expect(chef_run).to_not render_file('/etc/default/nginx')
+      expect(chef_run).to_not render_file('/etc/sysconfig/nginx')
+    end
+  end
+
+  context 'On RHEL 6' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'centos', version: '6.8').converge(described_recipe)
     end
 
-    it 'installs packages dependencies' do
-      expect(chef_run).to install_package(['pcre-devel', 'openssl-devel', 'tar'])
+    it 'creates init script' do
+      expect(chef_run).to render_file('/etc/init.d/nginx')
+    end
+
+    it 'generates defaults configuration' do
+      expect(chef_run).to render_file('/etc/sysconfig/nginx')
     end
   end
 
-  it 'downloads nginx sources' do
-    src_file = "#{Chef::Config['file_cache_path']}/nginx-#{@ngx_version}.tar.gz"
-    expect(chef_run).to create_remote_file(src_file).with(
-      backup: false
-    )
-  end
+  context 'On RHEL 7' do
+    cached(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511').converge(described_recipe)
+    end
 
-  it 'creates mime.types file' do
-    expect(chef_run).to create_cookbook_file('/etc/nginx/mime.types')
-  end
+    it 'creates systemd unit file' do
+      expect(chef_run).to render_file('/lib/systemd/system/nginx.service')
+    end
 
-  it 'marks nginx to be reloaded when we change the mime.types file' do
-    expect(chef_run.cookbook_file("#{chef_run.node['nginx']['dir']}/mime.types")).to notify('service[nginx]').to(:reload).delayed
-  end
-
-  it 'unarchives source' do
-    expect(chef_run).to run_bash('unarchive_source')
-  end
-
-  it 'includes all the source modules recipes' do
-    expect(chef_run).to include_recipe('chef_nginx::http_gzip_static_module')
-    expect(chef_run).to include_recipe('chef_nginx::http_ssl_module')
-  end
-
-  it 'compiles nginx source' do
-    expect(chef_run).to run_bash('compile_nginx_source')
-  end
-
-  it 'marks nginx to be reloaded when we compile nginx source' do
-    expect(chef_run.bash('compile_nginx_source')).to notify('service[nginx]').to(:restart).delayed
-  end
-
-  it 'marks ohai nginx to be reloaded when we compile nginx source' do
-    expect(chef_run.bash('compile_nginx_source')).to notify('ohai[reload_nginx]').to(:reload).immediately
-  end
-
-  context 'set up the init style' do
-    context 'without runit/upstart' do
-      cached(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'debian', version: '8.5') do |node|
-          node.normal['nginx']['init_style'] = 'other'
-        end.converge(described_recipe)
-      end
-      it 'enables daemon mode in nginx' do
-        expect(chef_run.node['nginx']['daemon_disable']).to be(false)
-      end
-      it 'defines nginx service' do
-        expect(chef_run).to enable_service('nginx')
-      end
-      context 'Debian familly' do
-        cached(:chef_run) do
-          ChefSpec::ServerRunner.new(platform: 'debian', version: '8.5') do |node|
-            node.normal['nginx']['init_style'] = 'other'
-          end.converge(described_recipe)
-        end
-        it 'creates init script' do
-          expect(chef_run).to render_file('/etc/init.d/nginx')
-        end
-        it 'generates defaults configuration' do
-          expect(chef_run).to render_file('/etc/default/nginx')
-        end
-      end
-      context 'Freebsd familly' do
-        cached(:chef_run) do
-          ChefSpec::ServerRunner.new(platform: 'freebsd', version: '10.3') do |node|
-            node.normal['nginx']['init_style'] = 'other'
-          end.converge(described_recipe)
-        end
-        it 'doesn\'t create the init script' do
-          expect(chef_run).to_not render_file('/etc/init.d/nginx')
-        end
-        it 'doesn\'t generate defaults configuration' do
-          expect(chef_run).to_not render_file('/etc/default/nginx')
-          expect(chef_run).to_not render_file('/etc/sysconfig/nginx')
-        end
-      end
-      context 'Other OS familly(Rhel y example)' do
-        cached(:chef_run) do
-          ChefSpec::ServerRunner.new(platform: 'centos', version: '6.8') do |node|
-            node.normal['nginx']['init_style'] = 'other'
-          end.converge(described_recipe)
-        end
-        it 'creates init script' do
-          expect(chef_run).to render_file('/etc/init.d/nginx')
-        end
-        it 'generates defaults configuration' do
-          expect(chef_run).to render_file('/etc/sysconfig/nginx')
-        end
-      end
+    it 'generates defaults configuration' do
+      expect(chef_run).to render_file('/etc/sysconfig/nginx')
     end
   end
-  context 'with runit' do
+
+  context 'On openSUSE 13.2' do
+    cached(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'opensuse', version: '13.2').converge(described_recipe)
+    end
+
+    it 'creates systemd unit file' do
+      expect(chef_run).to render_file('/usr/lib/systemd/system/nginx.service')
+    end
+
+    it 'generates defaults configuration' do
+      expect(chef_run).to render_file('/etc/sysconfig/nginx')
+    end
+  end
+
+  context 'with Runit init system set' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'debian', version: '8.5') do |node|
         node.normal['nginx']['init_style'] = 'runit'
@@ -150,28 +175,8 @@ describe 'chef_nginx::source' do
       expect(chef_run).to include_recipe('runit::default')
     end
 
-    it 'defines nginx service' do
-      expect(chef_run.service('nginx')).to do_nothing
-    end
-  end
-
-  context 'with upstart' do
-    cached(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'debian', version: '8.5') do |node|
-        node.normal['nginx']['init_style'] = 'upstart'
-      end.converge(described_recipe)
-    end
-
-    it 'disables daemon mode in nginx' do
-      expect(chef_run.node['nginx']['daemon_disable']).to be(true)
-    end
-
-    it 'creates the upstart script' do
-      expect(chef_run).to render_file('/etc/init/nginx.conf')
-    end
-
-    it 'defines nginx service' do
-      expect(chef_run.service('nginx')).to do_nothing
+    it 'defined runit_service' do
+      expect(chef_run).to enable_runit_service('nginx')
     end
   end
 end


### PR DESCRIPTION
Determine what init system to use based on the init_package attribute in Ohai not on a the attribute case statement.

No longer default Ubuntu to Runit. This makes no sense with modern init systems

Test all suites in Travis using kitchen-dokken
