### PR TITLE
Install 'ca-certificates' packages with passenger

### DIFF
--- a/recipes/repo_passenger.rb
+++ b/recipes/repo_passenger.rb
@@ -17,6 +17,7 @@
 
 if platform_family?('debian')
   include_recipe 'apt::default'
+  package 'ca-certificates'
 
   apt_repository 'phusionpassenger' do
     uri 'https://oss-binaries.phusionpassenger.com/apt/passenger'


### PR DESCRIPTION
It's a dependency according to https://www.phusionpassenger.com/library/install/nginx/install/oss/jessie/#step-1:-install-passenger-packages

I didn't see it being added in the `apt` cookbook or elsewhere. According to `apt-cache rdepends ca-certificates` it's not a dependency of `apt-transport-https` which was removed in 3.0.0 because it's included the `apt` cookbook.
