### PR TITLE
Systemd now no longer times out starting nginx in docker

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -51,6 +51,7 @@ platforms:
     platform: rhel
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
+      - ENV container docker
       - RUN yum -y install lsof which systemd-sysv initscripts
 
 - name: fedora-latest


### PR DESCRIPTION
systemd likes to know that it is running within a container, and it checks the container environment variable for this.

Fixes: chef-cookbooks/chef_nginx#16

http://developers.redhat.com/blog/2014/05/05/running-systemd-within-docker-container/
