### PR TITLE
fix only_if, reload nginx if template changed

### DIFF
--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -25,7 +25,6 @@ define :nginx_site, enable: true, timing: :delayed do
     template "#{node['nginx']['dir']}/sites-available/#{params[:name]}" do
       source params[:template]
       variables(params[:variables])
-      only_if { params[:only_if] }
       notifies :reload, 'service[nginx]', params[:timing]
     end
 

--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -25,6 +25,7 @@ define :nginx_site, enable: true, timing: :delayed do
     template "#{node['nginx']['dir']}/sites-available/#{params[:name]}" do
       source params[:template]
       variables(params[:variables])
+      only_if { params[:template] }
       notifies :reload, 'service[nginx]', params[:timing]
     end
 

--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -25,7 +25,8 @@ define :nginx_site, enable: true, timing: :delayed do
     template "#{node['nginx']['dir']}/sites-available/#{params[:name]}" do
       source params[:template]
       variables(params[:variables])
-      only_if { params[:template] }
+      only_if { params[:only_if] }
+      notifies :reload, 'service[nginx]', params[:timing]
     end
 
     execute "nxensite #{params[:name]}" do


### PR DESCRIPTION
### Description

Reload nginx if template changed, pass only_if block from definition block to template block
### Issues Resolved

WARN: only_if block for template[/etc/nginx/sites-available/blabla.conf] returned "blabla.conf.erb", did you mean to run a command? If so use 'only_if "chaply.conf.erb"' in your code.
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
