### PR TITLE
[GH-26] Remove guard on package[nginx] resource

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -41,7 +41,6 @@ end
 package node['nginx']['package_name'] do
   options package_install_opts
   notifies :reload, 'ohai[reload_nginx]', :immediately
-  not_if 'which nginx'
 end
 
 service 'nginx' do


### PR DESCRIPTION
### Description

Removes `not_if` guard on `package[nginx]` resource allowing better usage of `edit_resource` in wrapper cookbooks.
### Issues Resolved

GH-26
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] New functionality includes testing.  N/A
- [X] New functionality has been documented in the README if applicable.  N/A
- [X] All commits have been signed for the Developer Certificate of Origin. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
