### PR TITLE
Reload nginx on site change

### DIFF
--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -25,6 +25,7 @@ define :nginx_site, enable: true, timing: :delayed do
     template "#{node['nginx']['dir']}/sites-available/#{params[:name]}" do
       source params[:template]
       variables(params[:variables])
+      notifies :reload, 'service[nginx]', params[:timing]
       only_if { params[:template] }
     end
 


### PR DESCRIPTION
### Description

Reload nginx service when site, that has been already enabled, changes. It makes sure that the service is using up-to-date configuration.
### Issues Resolved

There is no corresponding issues, but it fixes the following scenario:
1. have a site that is already enabled
2. update the content using Chef converge
3. note that nginx is using the old configuration (reload was missing)
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

The problem with the checklist is that it is not possible to test `notifies` properly with the definition. Basically the following assertion will be successful with and without the change: 

``` ruby
context 'when the default site was aleady enabled' do
  before do
    allow(File).to receive(:symlink?).with('/etc/nginx/sites-enabled/default').and_return(true)
  end

  it 'marks nginx to be reloaded when changing the default site' do
    expect(chef_run.template('/etc/nginx/sites-available/default')).to notify('service[nginx]').to(:reload).delayed
  end
end
```
