### PR TITLE
nginx_site should reload nginx

### DIFF
--- a/definitions/nginx_site.rb
+++ b/definitions/nginx_site.rb
@@ -25,6 +25,7 @@ define :nginx_site, enable: true, timing: :delayed do
     template "#{node['nginx']['dir']}/sites-available/#{params[:name]}" do
       source params[:template]
       variables(params[:variables])
+      notifies :reload, 'service[nginx]', params[:timing]
       only_if { params[:template] }
     end
 


### PR DESCRIPTION
When using nginx_site provider with a template, nginx does not reload when you update your template.
nginx_site should reload nginx when the template is updated.
