### PR TITLE
Avoid splitting on compile params in the ohai plugin

### DIFF
--- a/templates/default/plugins/ohai-nginx.rb.erb
+++ b/templates/default/plugins/ohai-nginx.rb.erb
@@ -64,7 +64,7 @@ Ohai.plugin(:Nginx) do
             # This could be better: I'm splitting on configure arguments which removes them and also
             # adds a blank string at index 0 of the array. This is why we drop index 0 and map to
             # add the '--' prefix back to the configure argument.
-            nginx[:configure_arguments] = Regexp.last_match(1).split(/\s--/).drop(1).map { |ca| "--#{ca}" }
+            nginx[:configure_arguments] = Regexp.last_match(1).split(/\s--(?!param)/).drop(1).map { |ca| "--#{ca}" }
 
             prefix, conf_path = parse_flags(nginx[:configure_arguments])
 


### PR DESCRIPTION
### Description

Avoid splitting on the --param which was resulting in nginx recompiling on every run.
### Issues Resolved
#24
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

Signed-off-by: Tim Smith tsmith@chef.io
