### PR TITLE
Rework the testing cookbook a bit more

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -90,9 +90,9 @@ platforms:
       - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which hostname
 
 suites:
-  - name: default
+  - name: distro_packages
     run_list:
-      - recipe[test::default]
+      - recipe[test::distro_packages]
   - name: source
     run_list:
       - recipe[test::source]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,9 +31,9 @@ platforms:
       require_chef_omnibus: 12.1.0
 
 suites:
-  - name: default
+  - name: distro_packages
     run_list:
-      - recipe[test::default]
+      - recipe[test::distro_packages]
     excludes:
       - opensuse-13.2 # lacks nginx package
   - name: source

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,15 @@ services: docker
 
 env:
   matrix:
-  - INSTANCE=default-centos-6
-  - INSTANCE=default-centos-7
-  - INSTANCE=default-debian-7
-  - INSTANCE=default-debian-8
-  - INSTANCE=default-fedora-latest
-  - INSTANCE=default-opensuse-421
-  - INSTANCE=default-ubuntu-1204
-  - INSTANCE=default-ubuntu-1404
-  - INSTANCE=default-ubuntu-1604
+  - INSTANCE=distro-packages-centos-6
+  - INSTANCE=distro-packages-centos-7
+  - INSTANCE=distro-packages-debian-7
+  - INSTANCE=distro-packages-debian-8
+  - INSTANCE=distro-packages-fedora-latest
+  - INSTANCE=distro-packages-opensuse-421
+  - INSTANCE=distro-packages-ubuntu-1204
+  - INSTANCE=distro-packages-ubuntu-1404
+  - INSTANCE=distro-packages-ubuntu-1604
   - INSTANCE=source-centos-6
   - INSTANCE=source-centos-7
   - INSTANCE=source-debian-7

--- a/test/cookbooks/test/recipes/_base.rb
+++ b/test/cookbooks/test/recipes/_base.rb
@@ -1,4 +1,4 @@
-apt_update 'update' if platform_family?('debian')
+apt_update 'update'
 
 # needed for the specs
 package 'curl'

--- a/test/cookbooks/test/recipes/_test_site.rb
+++ b/test/cookbooks/test/recipes/_test_site.rb
@@ -1,0 +1,14 @@
+nginx_site 'default' do
+  enable false
+end
+
+template "#{node['nginx']['dir']}/sites-available/test_site" do
+  source 'site.erb'
+  mode '0644'
+  owner node['nginx']['user']
+  group node['nginx']['user']
+end
+
+nginx_site 'test_site' do
+  enable true
+end

--- a/test/cookbooks/test/recipes/distro_packages.rb
+++ b/test/cookbooks/test/recipes/distro_packages.rb
@@ -1,0 +1,1 @@
+include_recipe 'test::_base'

--- a/test/cookbooks/test/recipes/modules.rb
+++ b/test/cookbooks/test/recipes/modules.rb
@@ -15,4 +15,5 @@ node.default['nginx']['source']['modules'] = %w(
   chef_nginx::openssl_source
   chef_nginx::upload_progress_module)
 
-include_recipe 'chef_nginx::default'
+include_recipe 'test::_base'
+include_recipe 'test::_test_site'

--- a/test/cookbooks/test/recipes/source.rb
+++ b/test/cookbooks/test/recipes/source.rb
@@ -1,3 +1,4 @@
 node.default['nginx']['install_method'] = 'source'
 
-include_recipe 'chef_nginx::default'
+include_recipe 'test::_base'
+include_recipe 'test::_test_site'

--- a/test/cookbooks/test/recipes/upstream_repo.rb
+++ b/test/cookbooks/test/recipes/upstream_repo.rb
@@ -1,6 +1,6 @@
 node.default['nginx']['repo_source'] = 'nginx'
-
-apt_update 'update' if platform_family?('debian')
-
+apt_update 'update'
 include_recipe 'chef_nginx::repo'
-include_recipe 'chef_nginx::default'
+
+include_recipe 'test::_base'
+include_recipe 'test::_test_site'

--- a/test/cookbooks/test/templates/site.erb
+++ b/test/cookbooks/test/templates/site.erb
@@ -1,0 +1,11 @@
+server {
+  listen   <%= node['nginx']['port'] -%>;
+  server_name  <%= node['hostname'] %>;
+
+  access_log  <%= node['nginx']['log_dir'] %>/localhost.access.log;
+
+  location / {
+    root   <%= node['nginx']['default_root'] %>;
+    index  index.html index.htm;
+  }
+}


### PR DESCRIPTION
Rename the default suite so people understand that is a distro package suite
Add a _base recipe to dude things a bit
Remove the guard around apt_update since we fixed that bug in Chef / compat_resource
Test site setup so we actually get a test on how people would use this thing