### PR TITLE
Fix incorrect pids on Debian 8 with distro packages

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@ platforms:
   - name: centos-6.8
   - name: centos-7.2
   - name: debian-7.11
-  - name: debian-8.5
+  - name: debian-8.6
   - name: freebsd-9.3
     run_list: freebsd::portsnap
   - name: freebsd-10.3

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,9 +44,7 @@ default['nginx']['install_method'] = 'package'
 case node['platform_family']
 when 'debian'
   default['nginx']['user'] = 'www-data'
-  if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 14.04
-    default['nginx']['pid'] = '/run/nginx.pid'
-  end
+  default['nginx']['pid'] = '/run/nginx.pid' if node['init_package'] == 'systemd' || node['platform_version'].to_f == 14.04
 when 'rhel'
   default['nginx']['user']        = 'nginx'
 when 'fedora'


### PR DESCRIPTION
The new path is only on systemd based systems.

Signed-off-by: Tim Smith <tsmith@chef.io>