### PR TITLE
Determine pidfile location correctly via a helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Generally used attributes. Some have platform specific values. See `attributes/d
 - `node['nginx']['upstart']['foreground']` - Set this to true if you want upstart to run nginx in the foreground, set to false if you want upstart to detach and track the process via pid.
 - `node['nginx']['upstart']['runlevels']` - String of runlevels in the format '2345' which determines which runlevels nginx will start at when entering and stop at when leaving.
 - `node['nginx']['upstart']['respawn_limit']` - Respawn limit in upstart stanza format, count followed by space followed by interval in seconds.
-- `node['nginx']['pid']` - Location of the PID file.
 - `node['nginx']['keepalive']` - Whether to use `keepalive_timeout`, any value besides "on" will leave that option out of the config.
 - `node['nginx']['keepalive_requests']` - used for config value of `keepalive_requests`.
 - `node['nginx']['keepalive_timeout']` - used for config value of `keepalive_timeout`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,6 @@ default['nginx']['log_dir_perm'] = '0750'
 default['nginx']['binary']       = '/usr/sbin/nginx'
 default['nginx']['default_root'] = '/var/www/nginx-default'
 default['nginx']['ulimit']       = '1024'
-default['nginx']['pid']          = '/var/run/nginx.pid'
 
 # use the upstream nginx repo vs. distro packages
 # this enables the use of modern nginx releases
@@ -44,7 +43,6 @@ default['nginx']['install_method'] = 'package'
 case node['platform_family']
 when 'debian'
   default['nginx']['user'] = 'www-data'
-  default['nginx']['pid'] = '/run/nginx.pid' if node['init_package'] == 'systemd' || node['platform_version'].to_f == 14.04
 when 'rhel'
   default['nginx']['user']        = 'nginx'
 when 'fedora'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook:: chef_nginx
+# Library:: helpers
+#
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Copyright:: 2016, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# simple helper module for the nginx cookbook
+module NginxRecipeHelpers
+  # pidfile is hard to determine on Debian systems.
+  # Upstream packages and older distro releases use '/var/run/nginx.pid'
+  # systemd based distros and Ubuntu 14.04 use '/run/nginx.pid' for their
+  # packages
+  def pidfile_location
+    if (node['nginx']['repo_source'].nil? || node['nginx']['repo_source'] == 'distro') &&
+       (node['init_package'] == 'systemd' || node['platform_version'].to_f == 14.04)
+      '/run/nginx.pid'
+    else
+      '/var/run/nginx.pid'
+    end
+  end
+end
+
+Chef::Resource.send(:include, NginxRecipeHelpers)

--- a/recipes/commons_conf.rb
+++ b/recipes/commons_conf.rb
@@ -24,6 +24,7 @@ template 'nginx.conf' do
   source node['nginx']['conf_template']
   cookbook node['nginx']['conf_cookbook']
   notifies :reload, 'service[nginx]', :delayed
+  variables(lazy { { pid_file: pidfile_location } })
 end
 
 template "#{node['nginx']['dir']}/sites-available/default" do

--- a/recipes/commons_dir.rb
+++ b/recipes/commons_dir.rb
@@ -31,7 +31,8 @@ directory node['nginx']['log_dir'] do
   recursive true
 end
 
-directory File.dirname(node['nginx']['pid']) do
+directory 'pid file directory' do
+  path       lazy { File.dirname(pidfile_location) }
   mode      '0755'
   recursive true
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -122,6 +122,7 @@ when 'upstart'
 
   template '/etc/init/nginx.conf' do
     source 'nginx-upstart.conf.erb'
+    variables(lazy { { pid_file: pidfile_location } })
   end
 
   service 'nginx' do
@@ -161,6 +162,7 @@ else
   template '/etc/init.d/nginx' do
     source 'nginx.init.erb'
     mode   '0755'
+    variables(lazy { { pid_file: pidfile_location } })
   end if generate_init
 
   if generate_template # ~FC023

--- a/templates/debian/nginx.init.erb
+++ b/templates/debian/nginx.init.erb
@@ -14,7 +14,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=<%= node['nginx']['binary'] %>
 NAME=nginx
 DESC=nginx
-PID=<%= node['nginx']['pid'] %>
+PID=<%= @pid_file %>
 
 # Include nginx defaults if available
 if [ -f /etc/default/nginx ]; then

--- a/templates/default/nginx-upstart.conf.erb
+++ b/templates/default/nginx-upstart.conf.erb
@@ -6,7 +6,7 @@ start on (local-filesystems and net-device-up IFACE=lo and runlevel [<%= node['n
 stop on runlevel [!<%= node['nginx']['upstart']['runlevels'] %>]
 
 env DAEMON=<%= node['nginx']['binary'] %>
-env PID=<%= node['nginx']['pid'] %>
+env PID=<%= @pid_file %>
 env CONFIG=<%= node['nginx']['source']['conf_path'] %>
 
 respawn

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -8,7 +8,7 @@ worker_rlimit_nofile <%= node['nginx']['worker_rlimit_nofile'] %>;
 <% end -%>
 
 error_log  <%= node['nginx']['log_dir'] %>/error.log<% if node['nginx']['error_log_options'] %> <%= node['nginx']['error_log_options'] %><% end %>;
-pid        <%= node['nginx']['pid'] %>;
+pid        <%= @pid_file %>;
 events {
   worker_connections  <%= node['nginx']['worker_connections'] %>;
 <% if node['nginx']['multi_accept'] -%>

--- a/templates/ubuntu/nginx.init.erb
+++ b/templates/ubuntu/nginx.init.erb
@@ -14,7 +14,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=<%= node['nginx']['binary'] %>
 NAME=nginx
 DESC=nginx
-PID=<%= node['nginx']['pid'] %>
+PID=<%= @pid_file %>
 
 # Include nginx defaults if available
 if [ -f /etc/default/nginx ]; then


### PR DESCRIPTION
Debian/Ubuntu changed their pidfile location, but the upstream packages haven’t changed. This leads to an evil if statement that doesn’t work in attribute form due to overrides. Move this logic to a helper and remove the attribute. This is probably the first of many things that will move to helpers instead of attributes.

Signed-off-by: Tim Smith <tsmith@chef.io>