### PR TITLE
write passenger log to other location

### DIFF
--- a/attributes/passenger.rb
+++ b/attributes/passenger.rb
@@ -54,6 +54,8 @@ node.default['nginx']['passenger']['pool_idle_time'] = 300
 node.default['nginx']['passenger']['max_requests'] = 0
 node.default['nginx']['passenger']['gem_binary'] = nil
 node.default['nginx']['passenger']['show_version_in_header'] = 'on'
+# By default, the Passenger log file is the global Nginx error log file. Set this attribute to write passenger log to another location.
+node.default['nginx']['passenger']['passenger_log_file'] = nil
 
 # NodeJs disable by default
 node.default['nginx']['passenger']['nodejs'] = nil

--- a/templates/default/modules/passenger.conf.erb
+++ b/templates/default/modules/passenger.conf.erb
@@ -8,6 +8,9 @@ passenger_max_instances_per_app <%= node['nginx']['passenger']['max_instances_pe
 passenger_pool_idle_time <%= node['nginx']['passenger']['pool_idle_time'] %>;
 passenger_max_requests <%= node['nginx']['passenger']['max_requests'] %>;
 passenger_show_version_in_header <%= node['nginx']['passenger']['show_version_in_header'] %>;
+<%- if node['nginx']['passenger']['passenger_log_file'] %>
+  passenger_log_file <%= node['nginx']['passenger']['passenger_log_file'] %>;
+<% end %>
 
 <%- if node['nginx']['passenger']['nodejs'] %>
   passenger_nodejs <%= node['nginx']['passenger']['nodejs'] %>;


### PR DESCRIPTION
Signed-off-by: Nhan Nguyen <ducnhan813@gmail.com>

### Description

By default, the Passenger log file is the global Nginx error log file (`/var/log/nginx/error.log` by default). This PR enables Passenger to write log to another file.

### Issues Resolved


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
