### PR TITLE
Properly disable the default site with nginx.org packages

### DIFF
--- a/resources/site.rb
+++ b/resources/site.rb
@@ -72,7 +72,7 @@ action :disable do
   # normal script doesn't disable these.
   if new_resource.name == 'default' && ::File.exist?('/etc/nginx/conf.d/default.conf')
     execute 'Move nginx.org package default site config to sites-available' do
-      command "mv /etc/nginx/conf.d/default.conf #{node['nginx']['dir']}/sites-enabled/default"
+      command "mv /etc/nginx/conf.d/default.conf #{node['nginx']['dir']}/sites-available/default"
       user 'root'
       notifies :reload, 'service[nginx]'
     end

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -67,4 +67,14 @@ action :disable do
         ::File.symlink?("#{node['nginx']['dir']}/sites-enabled/000-#{new_resource.name}")
     end
   end
+
+  # The nginx.org packages store the default site at /etc/nginx/conf.d/default.conf and our
+  # normal script doesn't disable these.
+  if new_resource.name == 'default' && ::File.exist?('/etc/nginx/conf.d/default.conf')
+    execute 'Move nginx.org package default site config to sites-available' do
+      command "mv /etc/nginx/conf.d/default.conf #{node['nginx']['dir']}/sites-enabled/default"
+      user 'root'
+      notifies :reload, 'service[nginx]'
+    end
+  end
 end

--- a/spec/unit/recipes/commons_spec.rb
+++ b/spec/unit/recipes/commons_spec.rb
@@ -24,7 +24,7 @@ describe 'chef_nginx::commons' do
 
   # Describe individual recipes here instead of adding more files
   describe 'commons_dir recipe' do
-    %W(
+    %w(
       /etc/nginx
       /var/log/nginx
       /etc/nginx/sites-available
@@ -36,10 +36,9 @@ describe 'chef_nginx::commons' do
       end
     end
 
-    it "creates pid file directory" do
-      expect(chef_run).to create_directory("pid file directory").with(path: '/var/run')
+    it 'creates pid file directory' do
+      expect(chef_run).to create_directory('pid file directory').with(path: '/var/run')
     end
-
   end
 
   describe 'commons_script recipe' do


### PR DESCRIPTION
nginx.org packages use the conf.d folder to store sites. The script we install does not expect the default site to be here. If we’re trying to disable the default site we should delete it from conf.d

Signed-off-by: Tim Smith <tsmith@chef.io>