### PR TITLE
[CHEF-3694] Fix service[nginx] cloning resource error

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -45,9 +45,4 @@ package node['nginx']['package_name'] do
   notifies :reload, 'ohai[reload_nginx]', :immediately
 end
 
-service 'nginx' do
-  supports status: true, restart: true, reload: true
-  action   :enable
-end
-
 include_recipe 'chef_nginx::commons'


### PR DESCRIPTION
### Description

Removes `service[nginx]` declaration in the recipe package.rb as it is already declared in the default recipe.

### Issues Resolved

Fix issue https://github.com/chef-cookbooks/chef_nginx/issues/18

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
