### PR TITLE
Avoid deprecation warnings by only defining nginx service once

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,11 +21,6 @@
 
 include_recipe "chef_nginx::#{node['nginx']['install_method']}"
 
-service 'nginx' do
-  supports status: true, restart: true, reload: true
-  action   :start
-end
-
 node['nginx']['default']['modules'].each do |ngx_module|
   include_recipe "chef_nginx::#{ngx_module}"
 end

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -47,7 +47,7 @@ end
 
 service 'nginx' do
   supports status: true, restart: true, reload: true
-  action   :enable
+  action   [:start, :enable]
 end
 
 include_recipe 'chef_nginx::commons'

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -114,6 +114,7 @@ when 'runit'
   service 'nginx' do
     supports       status: true, restart: true, reload: true
     reload_command "#{node['runit']['sv_bin']} hup #{node['runit']['service_dir']}/nginx"
+    action         [:start, :enable]
   end
 when 'upstart'
   # we rely on this to set up nginx.conf with daemon disable instead of doing
@@ -128,7 +129,7 @@ when 'upstart'
   service 'nginx' do
     provider Chef::Provider::Service::Upstart
     supports status: true, restart: true, reload: true
-    action   :nothing
+    action   [:start, :enable]
   end
 when 'systemd'
 
@@ -141,7 +142,7 @@ when 'systemd'
   service 'nginx' do
     provider Chef::Provider::Service::Systemd
     supports status: true, restart: true, reload: true
-    action   :nothing
+    action   [:start, :enable]
   end
 else
   node.normal['nginx']['daemon_disable'] = false
@@ -173,7 +174,7 @@ else
 
   service 'nginx' do
     supports status: true, restart: true, reload: true
-    action   :enable
+    action   [:start, :enable]
   end
 end
 

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -70,7 +70,7 @@ action :disable do
 
   # The nginx.org packages store the default site at /etc/nginx/conf.d/default.conf and our
   # normal script doesn't disable these.
-  if new_resource.name == 'default' && ::File.exist?('/etc/nginx/conf.d/default.conf')
+  if new_resource.name == 'default' && ::File.exist?('/etc/nginx/conf.d/default.conf') # ~FC023
     execute 'Move nginx.org package default site config to sites-available' do
       command "mv /etc/nginx/conf.d/default.conf #{node['nginx']['dir']}/sites-available/default"
       user 'root'


### PR DESCRIPTION
I’m not entirely sure why this was ever done this way. perhaps a Chef 10 thing due to service definition ordering.

Signed-off-by: Tim Smith <tsmith@chef.io>