### PR TITLE
Rebuild shared library cache after installing luajit

### DIFF
--- a/recipes/lua.rb
+++ b/recipes/lua.rb
@@ -33,6 +33,7 @@ bash 'extract_luajit' do
     tar xzf #{luajit_src_filename} -C #{luajit_extract_path}
     cd luajit-#{node['nginx']['luajit']['version']}/LuaJIT-#{node['nginx']['luajit']['version']}
     make && make install
+    ldconfig
     export LUAJIT_INC="/usr/local/include/luajit-2.0"
     export LUAJIT_LIB="usr/local/lib"
   EOH


### PR DESCRIPTION
nginx won't start if using the lua module if it can't find the libluajit library, which is installed to /usr/local/lib. On Ubuntu (and maybe other distros?) ldconfig is configured to search /usr/local/lib by default, so all we need to do is rebuild the cache.