### PR TITLE
Add WantedBy to systemd service file

### DIFF
--- a/templates/default/nginx.service.erb
+++ b/templates/default/nginx.service.erb
@@ -10,3 +10,4 @@ ExecStop=/bin/kill -s QUIT $MAINPID
 PrivateTmp=true
 
 [Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### Description

The service file is used on systemd systems when nginx is built from source. It did not include the WantedBy option, so the service would not be automatically started at boot.

This adds the WantedBy option and uses the multi-user.target unit per the nginx example service file: https://www.nginx.com/resources/wiki/start/topics/examples/systemd/

### Issues Resolved

Fixes #42 