### PR TITLE
Set LUAJIT_INC and LUAJIT_LIB environment variables when configuring nginx

### DIFF
--- a/recipes/lua.rb
+++ b/recipes/lua.rb
@@ -34,8 +34,11 @@ bash 'extract_luajit' do
     cd luajit-#{node['nginx']['luajit']['version']}/LuaJIT-#{node['nginx']['luajit']['version']}
     make && make install
     ldconfig
-    export LUAJIT_INC="/usr/local/include/luajit-2.0"
-    export LUAJIT_LIB="usr/local/lib"
   EOH
   not_if { ::File.exist?(luajit_extract_path) }
 end
+
+node.run_state['nginx_source_env'].merge!(
+  'LUAJIT_INC' => '/usr/local/include/luajit-2.0',
+  'LUAJIT_LIB' => '/usr/local/lib/lua'
+)

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -58,6 +58,7 @@ end
 node.run_state['nginx_force_recompile'] = false
 node.run_state['nginx_configure_flags'] =
   node['nginx']['source']['default_configure_flags'] | node['nginx']['configure_flags']
+node.run_state['nginx_source_env'] = {}
 
 include_recipe 'chef_nginx::commons_conf'
 
@@ -83,12 +84,13 @@ end
 
 configure_flags       = node.run_state['nginx_configure_flags']
 nginx_force_recompile = node.run_state['nginx_force_recompile']
+env_string            = node.run_state['nginx_source_env'].map { |k, v| "#{k}=\"#{v}\"" }.join(' ')
 
 bash 'compile_nginx_source' do
   cwd  ::File.dirname(src_filepath)
   code <<-EOH
     cd nginx-#{node['nginx']['source']['version']} &&
-    ./configure #{node.run_state['nginx_configure_flags'].join(' ')} &&
+    #{env_string} ./configure #{node.run_state['nginx_configure_flags'].join(' ')} &&
     make && make install
   EOH
 


### PR DESCRIPTION
LUAJIT_INC and LUAJIT_LIB were previously exported after LuaJIT was built, but they were not available when the nginx configure script was run (which is when we need them). This might work, or it could allow nginx to be built against Lua (not JIT) if it's installed.

This gives us a mechanism to build up the environment necessary to build nginx (`nginx_source_env`), and sets LUAJIT_INC and LUAJIT_LIB there.