### PR TITLE
Don't preserve ownership of nginx source when unpacking tarball

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -73,7 +73,7 @@ end
 bash 'unarchive_source' do
   cwd  ::File.dirname(src_filepath)
   code <<-EOH
-    tar zxf #{::File.basename(src_filepath)} -C #{::File.dirname(src_filepath)}
+    tar zxf #{::File.basename(src_filepath)} -C #{::File.dirname(src_filepath)} --no-same-owner
   EOH
   not_if { ::File.directory?("#{Chef::Config['file_cache_path'] || '/tmp'}/nginx-#{node['nginx']['source']['version']}") }
 end


### PR DESCRIPTION
`tar` defaults to `--same-owner` for root, so it has to be explicitly disabled.  This was causing weird issues for us, and I can't imagine anyone wants that behavior anyway.