### PR TITLE
Setup LD options to include /usr/local/lib for libluajit in search path

### DIFF
--- a/attributes/lua.rb
+++ b/attributes/lua.rb
@@ -19,9 +19,9 @@
 # limitations under the License.
 #
 
-default['nginx']['lua']['version']  = '0.10.3'
+default['nginx']['lua']['version']  = '0.10.7'
 default['nginx']['lua']['url']      = "https://github.com/chaoslawful/lua-nginx-module/archive/v#{node['nginx']['lua']['version']}.tar.gz"
-default['nginx']['lua']['checksum'] = 'a69504c25de67bce968242d331d2e433c021405a6dba7bca0306e6e0b040bb50'
+default['nginx']['lua']['checksum'] = 'c21c8937dcdd6fc2b6a955f929e3f4d1388610f47180e60126e6dcab06786f77'
 
 default['nginx']['luajit']['version']  = '2.0.4'
 default['nginx']['luajit']['url']	     = "http://luajit.org/download/LuaJIT-#{node['nginx']['luajit']['version']}.tar.gz"

--- a/recipes/lua.rb
+++ b/recipes/lua.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: nginx
-# Recipe:: default
+# Recipe:: lua
 #
 # Copyright:: 2013-2017, Chef Software, Inc.
 #
@@ -33,12 +33,14 @@ bash 'extract_luajit' do
     tar xzf #{luajit_src_filename} -C #{luajit_extract_path}
     cd luajit-#{node['nginx']['luajit']['version']}/LuaJIT-#{node['nginx']['luajit']['version']}
     make && make install
-    ldconfig
   EOH
   not_if { ::File.exist?(luajit_extract_path) }
 end
 
 node.run_state['nginx_source_env'].merge!(
   'LUAJIT_INC' => '/usr/local/include/luajit-2.0',
-  'LUAJIT_LIB' => '/usr/local/lib/lua'
+  'LUAJIT_LIB' => '/usr/local/lib'
 )
+
+node.run_state['nginx_configure_flags'] =
+    node.run_state['nginx_configure_flags'] | ['--with-ld-opt="-Wl,-rpath,/usr/local/lib"']

--- a/recipes/ngx_lua_module.rb
+++ b/recipes/ngx_lua_module.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: nginx
-# Recipes:: lua
+# Recipes:: nginx_lua_module
 #
 # Author:: Arthur Freyman (<afreyman@riotgames.com>)
 #


### PR DESCRIPTION
Signed-off-by: Antek S. Baranski <antek.baranski@gmail.com>

### Description
Setup LD options to include /usr/local/lib for libluajit in search path
Bump lua-nginx-module version to 0.10.7
Fix comments for both lua.rb & ngx_lua_module.rb recipes

### Issues Resolved

https://github.com/chef-cookbooks/chef_nginx/issues/81

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
