### PR TITLE
Add image/svg+xml to gzip_files defaults

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -82,6 +82,7 @@ default['nginx']['gzip_types'] = %w(
   application/xml
   application/rss+xml
   application/atom+xml
+  image/svg+xml
   text/javascript
   application/javascript
   application/json


### PR DESCRIPTION
SVG compresses really well

### Description

Adds gzip compression for SVG files

### Issues Resolved

This is commonly recommended by [Google PageSpeed](https://developers.google.com/speed/pagespeed/)

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
