### PR TITLE
double quotes are unnecessary in lua configure flags

### DIFF
--- a/recipes/lua.rb
+++ b/recipes/lua.rb
@@ -43,4 +43,4 @@ node.run_state['nginx_source_env'].merge!(
 )
 
 node.run_state['nginx_configure_flags'] =
-  node.run_state['nginx_configure_flags'] | ['--with-ld-opt="-Wl,-rpath,/usr/local/lib"']
+  node.run_state['nginx_configure_flags'] | ['--with-ld-opt=-Wl,-rpath,/usr/local/lib']


### PR DESCRIPTION
### Description

If applied twice with the same version, nginx will not compile twice.

Before

https://github.com/chef-cookbooks/chef_nginx/blob/master/recipes/source.rb#L101

`node.automatic_attrs['nginx']['configure_arguments'].sort` is below (double quotes in with-ld-opt).
```
--add-module=/var/chef/cache/nginx-devel-0.3.0/ngx_devel_kit-0.3.0 --add-module=/var/chef/cache/nginx-lua-0.10.7/lua-nginx-module-0.10.7 --conf-path=/etc/nginx/nginx.conf --prefix=/opt/nginx --sbin-path=/opt/nginx/sbin/nginx --with-http_ssl_module --with-http_stub_status_module --with-http_v2_module --with-ld-opt="-Wl,-rpath,/usr/local/lib" --with-openssl=/var/chef/cache/openssl-1.0.2k
```

`nginx -V` result (no double quotes in with-ld-opt)
```
nginx version: nginx/1.11.5
built by gcc 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.3)
built with OpenSSL 1.0.2k  26 Jan 2017
TLS SNI support enabled
configure arguments: --prefix=/opt/nginx --conf-path=/etc/nginx/nginx.conf --sbin-path=/opt/nginx/sbin/nginx --with-openssl=/var/chef/cache/openssl-1.0.2k --with-http_ssl_module --with-http_stub_status_module --with-http_v2_module --add-module=/var/chef/cache/nginx-lua-0.10.7/lua-nginx-module-0.10.7 --with-ld-opt=-Wl,-rpath,/usr/local/lib --add-module=/var/chef/cache/nginx-devel-0.3.0/ngx_devel_kit-0.3.0
```

### Issues Resolved

#86

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
