### PR TITLE
support `worker_shutdown_timeout` released in 1.11.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Generally used attributes. Some have platform specific values. See `attributes/d
 - `node['nginx']['worker_processes']` - used for config value of `worker_processes`.
 - `node['nginx']['worker_connections']` - used for config value of `events { worker_connections }`
 - `node['nginx']['worker_rlimit_nofile']` - used for config value of `worker_rlimit_nofile`. Can replace any "ulimit -n" command. The value depend on your usage (cache or not) but must always be superior than worker_connections.
+- `node['nginx']['worker_shutdown_timeout']` - used for config value of `worker_shutdown_timeout`.
+- `node['nginx']['worker_connections']` - used for config value of `events { worker_connections }`
 - `node['nginx']['multi_accept']` - used for config value of `events { multi_accept }`. Try to accept() as many connections as possible. Disable by default.
 - `node['nginx']['event']` - used for config value of `events { use }`. Set the event-model. By default nginx looks for the most suitable method for your OS.
 - `node['nginx']['accept_mutex_delay']` - used for config value of `accept_mutex_delay`

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -6,6 +6,9 @@ daemon off;
 <% if node['nginx']['worker_rlimit_nofile'] -%>
 worker_rlimit_nofile <%= node['nginx']['worker_rlimit_nofile'] %>;
 <% end -%>
+<% if node['nginx']['worker_shutdown_timeout'] -%>
+worker_shutdown_timeout <%= node['nginx']['worker_shutdown_timeout'] %>;
+<% end -%>
 <% node['nginx']['load_modules'].each do |module_to_load| %>
 load_module <%= module_to_load %>;
 <% end -%>


### PR DESCRIPTION
changelog: http://nginx.org/en/CHANGES
docs about it: http://nginx.org/en/docs/ngx_core_module.html#worker_shutdown_timeout