### PR TITLE
Remove runit init system support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The following cookbooks are direct dependencies because they're used for common 
 
 - `build-essential` for source installations
 - `ohai` for setting up the ohai plugin
-- `runit` for source installs using the runit init system
 - `compat_resource` for setting up the nginx.org repository on Chef 12.1 - 12.13
 - `yum-epel` for setting up the EPEL repository on RHEL platforms
 - `zypper` for setting up the nginx.org repository on Suse platforms
@@ -63,7 +62,7 @@ Generally used attributes. Some have platform specific values. See `attributes/d
 - `node['nginx']['group']` - Group for nginx.
 - `node['nginx']['port']` - Port for nginx to listen on.
 - `node['nginx']['binary']` - Path to the nginx binary.
-- `node['nginx']['init_style']` - How to run nginx as a service when using `chef_nginx::source`. Values can be "runit", "upstart", "systemd", or "init". When using runit that recipes will be included as well. This attribute is not used in the `package` recipe because the package manager's init script style for the platform is assumed.
+- `node['nginx']['init_style']` - How to run nginx as a service when using `chef_nginx::source`. Values can be "upstart", "systemd", or "init". This attribute is not used in the `package` recipe because the package manager's init script style for the platform is assumed.
 - `node['nginx']['upstart']['foreground']` - Set this to true if you want upstart to run nginx in the foreground, set to false if you want upstart to detach and track the process via pid.
 - `node['nginx']['upstart']['runlevels']` - String of runlevels in the format '2345' which determines which runlevels nginx will start at when entering and stop at when leaving.
 - `node['nginx']['upstart']['respawn_limit']` - Respawn limit in upstart stanza format, count followed by space followed by interval in seconds.

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,6 @@ recipe 'chef_nginx::source', 'Installs nginx from source and sets up configurati
 depends 'build-essential'
 depends 'ohai', '>= 4.1.0'
 depends 'yum-epel'
-depends 'runit', '>= 1.6.0'
 depends 'compat_resource', '>= 12.16.3'
 depends 'zypper'
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -106,18 +106,6 @@ bash 'compile_nginx_source' do
 end
 
 case node['nginx']['init_style']
-when 'runit'
-  Chef::Log.warn('The usage of the runit init system for nginx is highly discouraged. Modern distro init systems will more than likely provide you with a better experience. Runit will be removed from this cookbook in the future.')
-  node.normal['nginx']['src_binary'] = node['nginx']['binary']
-  include_recipe 'runit::default'
-
-  runit_service 'nginx'
-
-  service 'nginx' do
-    supports       status: true, restart: true, reload: true
-    reload_command "#{node['runit']['sv_bin']} hup #{node['runit']['service_dir']}/nginx"
-    action         [:start, :enable]
-  end
 when 'upstart'
   # we rely on this to set up nginx.conf with daemon disable instead of doing
   # it in the upstart init script.

--- a/spec/unit/recipes/source_spec.rb
+++ b/spec/unit/recipes/source_spec.rb
@@ -135,20 +135,4 @@ describe 'chef_nginx::source' do
       expect(chef_run).to render_file('/usr/lib/systemd/system/nginx.service')
     end
   end
-
-  context 'with Runit init system set' do
-    let(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'debian', version: '8.5') do |node|
-        node.normal['nginx']['init_style'] = 'runit'
-      end.converge(described_recipe)
-    end
-
-    it 'includes runit recipe' do
-      expect(chef_run).to include_recipe('runit::default')
-    end
-
-    it 'defined runit_service' do
-      expect(chef_run).to enable_runit_service('nginx')
-    end
-  end
 end


### PR DESCRIPTION
This was not a great experience, didn’t work on all platforms, and in general provided little benefit over using systemd or upstart.

Signed-off-by: Tim Smith <tsmith@chef.io>