### PR TITLE
Correctly compare nginx versions with multiple digits

### DIFF
--- a/libraries/nginx_version.rb
+++ b/libraries/nginx_version.rb
@@ -1,0 +1,37 @@
+class NginxVersion
+  include Comparable
+
+  attr_reader :version
+
+  def initialize(version)
+    @version = version
+  end
+
+  def <=>(other)
+    lhsegments = segments
+    rhsegments = other.segments
+
+    parts = [lhsegments.size, rhsegments.size].max
+
+    (0..(parts - 1)).each do |index|
+      lhs = lhsegments[index] || 0
+      rhs = rhsegments[index] || 0
+
+      next if lhs == rhs
+
+      return lhs <=> rhs
+    end
+
+    0
+  end
+
+  def to_s
+    version
+  end
+
+  protected
+
+  def segments
+    version.split('.').map { |part| Integer(part) }
+  end
+end

--- a/spec/libraries/nginx_version_spec.rb
+++ b/spec/libraries/nginx_version_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require_relative '../../libraries/nginx_version'
+
+describe NginxVersion do
+  let(:version) { '1.10.3' }
+
+  subject { described_class.new(version) }
+
+  RSpec::Matchers.define :be_greater_than do |expected|
+    match do |actual|
+      actual > expected
+    end
+  end
+
+  RSpec::Matchers.define :be_less_than do |expected|
+    match do |actual|
+      actual < expected
+    end
+  end
+
+  describe 'comparison' do
+    it 'compares versions differing in major part' do
+      other = described_class.new('0.10.3')
+
+      expect(subject).to be_greater_than(other)
+      expect(other).to be_less_than(subject)
+    end
+
+    it 'compares versions differing in minor part' do
+      other = described_class.new('1.2.3')
+
+      expect(subject).to be_greater_than(other)
+      expect(other).to be_less_than(subject)
+    end
+
+    it 'compares versions differing in patch part' do
+      other = described_class.new('1.10.1')
+
+      expect(subject).to be_greater_than(other)
+      expect(other).to be_less_than(subject)
+    end
+
+    it 'compares versions with different numbers of segments' do
+      other = described_class.new('1.10')
+
+      expect(subject).to be_greater_than(other)
+      expect(other).to be_less_than(subject)
+    end
+
+    it 'reports equality when versions exactly match' do
+      other = described_class.new(version)
+
+      expect(subject).to eq(other)
+    end
+  end
+end

--- a/spec/unit/recipes/http_realip_module_spec.rb
+++ b/spec/unit/recipes/http_realip_module_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'chef_nginx::http_realip_module' do
+  let(:nginx_version) { '1.10.3' }
+
+  let(:chef_run) do
+    ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+      node.normal['nginx']['source']['modules'] = ['chef_nginx::http_realip_module']
+      node.normal['nginx']['version'] = nginx_version
+      node.normal['nginx']['realip']['real_ip_recursive'] = 'off'
+    end.converge('chef_nginx::package', described_recipe)
+  end
+
+  it 'creates config file' do
+    expect(chef_run).to create_template('/etc/nginx/conf.d/http_realip.conf')
+  end
+
+  it 'includes the real_ip_recursive configuration directive' do
+    expect(chef_run).to render_file('/etc/nginx/conf.d/http_realip.conf').with_content(
+      'real_ip_recursive off'
+    )
+  end
+
+  context 'when the nginx version is < 1.2' do
+    let(:nginx_version) { '1.1' }
+
+    it 'does not include the real_ip_recursive configuration directive' do
+      expect(chef_run).to render_file('/etc/nginx/conf.d/http_realip.conf').with_content { |content|
+        expect(content).not_to include('real_ip_recursive')
+      }
+    end
+  end
+end

--- a/templates/default/modules/http_realip.conf.erb
+++ b/templates/default/modules/http_realip.conf.erb
@@ -2,6 +2,6 @@
 set_real_ip_from <%= address %>;
 <% end -%>
 real_ip_header <%= node['nginx']['realip']['header'] %>;
-<% if node['nginx']['version'].to_f >= 1.2 -%>
+<% if NginxVersion.new(node['nginx']['version']) >= NginxVersion.new('1.2') -%>
 real_ip_recursive <%= node['nginx']['realip']['real_ip_recursive'] %>;
 <% end -%>


### PR DESCRIPTION
### Description

The version comparison in the `http_realip.conf.erb` template used `#to_f` on the nginx version string to test for versions >= 1.2. However, this fails in a number of scenarios.

For example, the current default nginx version attribute is '1.10.3', a later release than 1.2. However, `'1.10.3'.to_f` returns `1.1`, for which the numerical test fails, causing the real_ip_recursive directive to be incorrectly omitted.

This change introduces a version comparison helper, which [follows the pattern from `Gem::Version`](https://github.com/rubygems/rubygems/blob/3f3337e6b789fc127f1aaa6e9895472446de0638/lib/rubygems/version.rb#L336-L361), simplified to remove the ability to compare version strings with non-numeric parts. I chose to do this rather than use `Gem::Version` itself, as it doesn't seem that [nginx uses non-numeric version identifiers](http://nginx.org/en/CHANGES-1.12), so I couldn't be confident that, if nginx ever did so, `Gem::Version`'s interpretation of a version string will match nginx's.

I hope this is okay - I've introduced both library unit tests and a recipe test for the realip module - if the latter is overkill I'm happy to remove it.

### Issues Resolved

None, excepting the PR itself.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
