### PR TITLE
Correct documentation for `rate_limiting_backoff` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Basic configuration to use the official Phusion Passenger repositories:
 
 - `node['nginx']['enable_rate_limiting']` - set to true to enable rate limiting (`limit_req_zone` in nginx.conf)
 - `node['nginx']['rate_limiting_zone_name']` - sets the zone in `limit_req_zone`.
-- `node['nginx']['rate_limiting_backoff']` - sets the backoff time for `limit_req_zone`.
+- `node['nginx']['rate_limiting_backoff']` - **Incorrect name, retained for compatibility reasons** - sets the size of the shared memory zone (default=`10m`, 10 megabytes)
 - `node['nginx']['rate_limit']` - set the rate limit amount for `limit_req_zone`.
 
 ### chef_nginx::repo


### PR DESCRIPTION
### Description

The `rate_limiting_backoff` attribute has been documented, in accordance with its name, as the rate-limiting backoff period for a zone. However, the `limit_req_zone` directive it applies to [has no such option](http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone) - the attribute is instead used by this cookbook to supply the size of the rate-limit zone, the shared memory area that's used to store the state used for rate monitoring.

Since we can't change the name of the attribute without breaking existing client attribute customisations[*], this change documents the attribute's effect and notes that the name is incorrect.

[*] Or at least, I can't think of a sensible way to do so right now - any suggestions would be extremely welcome. Is it possible to alias attributes somehow, so that both the incorrect name and an updated one could be supported in parallel?

### Issues Resolved

N/A

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD> [N/A]
- [x] New functionality includes testing. [N/A]
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
