### PR TITLE
Install basic configuration before starting the nginx service

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -45,9 +45,9 @@ package node['nginx']['package_name'] do
   notifies :reload, 'ohai[reload_nginx]', :immediately
 end
 
+include_recipe 'chef_nginx::commons'
+
 service 'nginx' do
   supports status: true, restart: true, reload: true
   action   [:start, :enable]
 end
-
-include_recipe 'chef_nginx::commons'


### PR DESCRIPTION
If done the other way around, the nginx service may fail to start if
something else is already listening on port 80, depending on what
configuration comes by default from the package.

Signed-off-by: Jarkko Oranen <oranenj@iki.fi>

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
