### PR TITLE
wrong pidfile detection on Ubuntu + passenger package 

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -26,7 +26,7 @@ module NginxRecipeHelpers
   # systemd based distros and Ubuntu 14.04 use '/run/nginx.pid' for their
   # packages
   def pidfile_location
-    if (node['nginx']['repo_source'].nil? || node['nginx']['repo_source'] == 'distro') &&
+    if (node['nginx']['repo_source'].nil? || %w(distro passenger).include?(node['nginx']['repo_source'])) &&
        (node['init_package'] == 'systemd' || node['platform_version'].to_f == 14.04)
       '/run/nginx.pid'
     else


### PR DESCRIPTION
### Description

Actually, when installing nginx (1.10.1) from the [Phusion Passenger package repository](https://oss-binaries.phusionpassenger.com/), the PID location is `/run/nginx.pid` but this is wrongly detected by the cookbook configuration recipe. We end up with a nginx service that cannot be reloaded after initial converge, because the pid file set in config file does not exist.

### Issues Resolved

The nginx configuration now contains the correct PID location when installing with `node['nginx']['install_method = 'package` and  `node['nginx']['repo_source'] = 'passenger'`