### PR TITLE
Update Nginx version to current stable [1.12.1]

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@
 
 # In order to update the version, the checksum attribute must be changed too.
 # This attribute is defined in the source.rb attribute file
-default['nginx']['version']      = '1.10.3'
+default['nginx']['version']      = '1.12.1'
 default['nginx']['package_name'] = 'nginx'
 default['nginx']['port']         = '80'
 default['nginx']['dir']          = '/etc/nginx'

--- a/attributes/echo.rb
+++ b/attributes/echo.rb
@@ -19,6 +19,6 @@
 # limitations under the License.
 #
 
-default['nginx']['echo']['version']        = '0.59'
+default['nginx']['echo']['version']        = '0.61'
 default['nginx']['echo']['url']            = "https://github.com/openresty/echo-nginx-module/archive/v#{node['nginx']['echo']['version']}.tar.gz"
-default['nginx']['echo']['checksum']       = '9b319ad7836202883128d2b9c24ed818082541df57ef7f2065b7557085c603cd'
+default['nginx']['echo']['checksum']       = '2e6a03032555f5da1bdff2ae96c96486f447da3da37c117e0f964ae0753d22aa'

--- a/attributes/lua.rb
+++ b/attributes/lua.rb
@@ -19,9 +19,9 @@
 # limitations under the License.
 #
 
-default['nginx']['lua']['version']  = '0.10.7'
+default['nginx']['lua']['version']  = '0.10.10'
 default['nginx']['lua']['url']      = "https://github.com/chaoslawful/lua-nginx-module/archive/v#{node['nginx']['lua']['version']}.tar.gz"
-default['nginx']['lua']['checksum'] = 'c21c8937dcdd6fc2b6a955f929e3f4d1388610f47180e60126e6dcab06786f77'
+default['nginx']['lua']['checksum'] = 'b4acb84e2d631035a516d61830c910ef6e6485aba86096221ec745e0dbb3fbc9'
 
 default['nginx']['luajit']['version']  = '2.0.4'
 default['nginx']['luajit']['url']	     = "http://luajit.org/download/LuaJIT-#{node['nginx']['luajit']['version']}.tar.gz"

--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -41,7 +41,7 @@ default['nginx']['source']['default_configure_flags'] = %W(
 default['nginx']['configure_flags']    = []
 default['nginx']['source']['version']  = node['nginx']['version']
 default['nginx']['source']['url']      = "http://nginx.org/download/nginx-#{node['nginx']['source']['version']}.tar.gz"
-default['nginx']['source']['checksum'] = '75020f1364cac459cb733c4e1caed2d00376e40ea05588fb8793076a4c69dd90'
+default['nginx']['source']['checksum'] = '8793bf426485a30f91021b6b945a9fd8a84d87d17b566562c3797aba8fac76fb'
 default['nginx']['source']['modules']  = %w(
   chef_nginx::http_ssl_module
   chef_nginx::http_gzip_static_module

--- a/spec/unit/recipes/http_realip_module_spec.rb
+++ b/spec/unit/recipes/http_realip_module_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'chef_nginx::http_realip_module' do
-  let(:nginx_version) { '1.10.3' }
+  let(:nginx_version) { '1.12.1' }
 
   let(:chef_run) do
     ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|

--- a/test/integration/modules/headers_more_module_spec.rb
+++ b/test/integration/modules/headers_more_module_spec.rb
@@ -1,5 +1,5 @@
 # FIXME: This will not sustain a version update
-describe command('/opt/nginx-1.10.3/sbin/nginx -V') do
+describe command('/opt/nginx-1.12.1/sbin/nginx -V') do
   its(:stderr) { should match(/headers_more/) }
 end
 

--- a/test/integration/modules/http_geoip_module_spec.rb
+++ b/test/integration/modules/http_geoip_module_spec.rb
@@ -8,7 +8,7 @@ describe file('/usr/local/lib/libGeoIP.so') do
 end
 
 # FIXME: This will not sustain a version update
-describe command('/opt/nginx-1.10.3/sbin/nginx -V') do
+describe command('/opt/nginx-1.12.1/sbin/nginx -V') do
   its(:stderr) { should match(/--with-http_geoip_module/) }
 end
 


### PR DESCRIPTION
Update nginx to the current stable version when installing via source.
This version fixes integer overflow in the range filter vulnerability (CVE-2017-7529).
Also update versions of echo-nginx-module and lua-nginx-module to fix failing specs.
