### PR TITLE
set ULIMIT in nginx.sysconfig.erb

### DIFF
--- a/templates/default/nginx.sysconfig.erb
+++ b/templates/default/nginx.sysconfig.erb
@@ -1,1 +1,2 @@
 NGINX_GLOBAL=<%= node['nginx']['global'] %>
+ULIMIT="-n <%= node['nginx']['ulimit'] %>"


### PR DESCRIPTION
This PR fixes "Too many open files" error.
![monosnap 2017-09-13 17-45-45](https://user-images.githubusercontent.com/134610/30383876-649e6330-98ab-11e7-97ea-9b593ee3ca0f.png)

This is a critical issue. Without this fix nginx can't be used under heavy load.
http://serverfault.com/questions/641899/ulimit-file-descriptor-limits-not-being-applied-for-particular-process
